### PR TITLE
Add Sudo to gem install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you wish to run the tool locally, you need to do it through a local web serve
 
 _Protip™_: If you use Ruby, you can spin up a web server in the current directory with this one-liner:
 
-    gem install thin; ruby -rrack -e "include Rack; Handler::Thin.run Builder.new { run Directory.new '' }"
+   sudo gem install thin; ruby -rrack -e "include Rack; Handler::Thin.run Builder.new { run Directory.new '' }"
 
 One alternative is to run Chrome with the `--allow-access-from-files` parameter.
 


### PR DESCRIPTION
We need to add sudo in front of gem install or else installation will
fail.
