### PR TITLE
Ability to specify an HD master node's derivation

### DIFF
--- a/lib/multisig/address.js
+++ b/lib/multisig/address.js
@@ -43,12 +43,21 @@ Address.prototype = {
     // Do this async, to not block rendering.
     setTimeout(function() {
       // Derive the child pubkey for each master node.
-      var pubkeys = this.masterNodes.map(function(node) { return node.derive(this.index).pubKey; }.bind(this));
+      var pubkeys = this.masterNodes.map(function(node) {
+        var pubKey = node.hd_node.derive(this.index).pubKey;
 
-      // Uncompress the pubkeys.
-      this.pubkeys = pubkeys.map(function(pubKey) {
-        return new Bitcoin.ECPubKey(pubKey.Q, false);
-      }).sort(this.comparePubKeys); // And sort them by their hex values.
+        // We get information about whether a certain master key should be compressed or uncompressed from Coinbase.com
+        // through URL parameters, like compressed[]=1&compressed[]=2 would signal that xpubkey1's and xpubkey2's children
+        // should all be compressed, whereas xpubkey3's children should be uncompressed.
+        if (!node.compressed) {
+          return new Bitcoin.ECPubKey(pubKey.Q, false); // Uncompress key if necessary.
+        }
+
+        return pubKey;
+      }.bind(this));
+
+      this.pubkeys = pubkeys.sort(this.comparePubKeys); // Sort them by their hex values.
+
       if (constants.DEBUG) console.log('Generating address', this.pubkeys);
 
       // Generate the redeemScript.

--- a/lib/multisig/vault.js
+++ b/lib/multisig/vault.js
@@ -48,7 +48,11 @@ Vault.prototype = {
   createAddresses: function() {
     // Generate the master HD nodes with the xpubkeys.
     var masterNodes = this.xpubkeys.map(function(xpubkey) {
-      return Bitcoin.HDNode.fromBase58(xpubkey);
+      // xpubkey = [xpubkey_string, xpubkey_compressed_boolean]
+      return {
+        hd_node: Bitcoin.HDNode.fromBase58(xpubkey[0]),
+        compressed: xpubkey[1]
+      }
     });
 
     // Create an address for each index.

--- a/lib/tool.js
+++ b/lib/tool.js
@@ -36,6 +36,11 @@ $(function() {
       var value = decodeURIComponent(pair[1]);
       if (!value) continue;
 
+      // Special case for handling which xpubkey's descendents should be compressed.
+      if (key == 'compressed[]') {
+        $("#xpubkey" + value).data('compressed', 'true');
+      }
+
       // Look up the element from the key_to_element table and prefill it with the value.
       $(key_to_element[key]).val(value);
     }
@@ -55,7 +60,13 @@ $(function() {
   // Step 1, collect the xpubkeys, construct child addresses and fetch their unspent outputs.
   $('#step_1 button').on('click', function() {
     var lastAddressIndex = $('.max_index input').val();
-    var xpubkeys = $('.xpubkey').map(function(i, xpub) { return cleanInput($(xpub).val()); }).toArray();
+    var xpubkeys = [];
+    $('.xpubkey').each(function(i, xpub) {
+      xpubkeys.push([
+        cleanInput($(xpub).val()),
+        ($(xpub).data('compressed') == 'true')
+      ]);
+    });
 
     // Build up the main Vault object.
     vault = new Vault({


### PR DESCRIPTION
This adds the ability for the Coinbase.com app to tell whether a master key should derive compressed or uncompressed keys through URL parameters.

> In the new Coinbase multisig vaults, the Coinbase key has compressed child pubkeys, whereas the other two keys still have uncompressed.
