### PR TITLE
Restore ability to copy-paste keys directly.

### DIFF
--- a/css/multisig.css
+++ b/css/multisig.css
@@ -88,6 +88,11 @@ textarea, input[type="text"], input[type="number"], input[type="password"] {
   float: left;
   text-align: center;
 }
+.xpubkey_footer {
+  width: 33%;
+  float: left;
+  margin-bottom: 10px;
+}
 .xpubkeys textarea {
   width: 31%;
   height: 60px;

--- a/css/multisig.css
+++ b/css/multisig.css
@@ -83,6 +83,11 @@ textarea, input[type="text"], input[type="number"], input[type="password"] {
   color: #ccc;
 }
 
+.xpubkey_header {
+  width: 33%;
+  float: left;
+  text-align: center;
+}
 .xpubkeys textarea {
   width: 31%;
   height: 60px;

--- a/index.html
+++ b/index.html
@@ -33,6 +33,16 @@
           <textarea id="xpubkey1" class="xpubkey key" placeholder="xpub..."></textarea>
           <textarea id="xpubkey2" class="xpubkey key" placeholder="xpub..."></textarea>
           <textarea id="xpubkey3" class="xpubkey key" placeholder="xpub..."></textarea>
+          <div class="xpubkey_footer">
+            <small><input type="checkbox" id="xpubkey1_compressed"/>Compressed key</small>
+          </div>
+          <div class="xpubkey_footer">
+            <small><input type="checkbox" id="xpubkey2_compressed"/>Compressed key</small>
+          </div>
+          <div class="xpubkey_footer">
+            <small><input type="checkbox" id="xpubkey3_compressed"/>Compressed key</small>
+          </div>
+          <small>Uncheck "Compressed key" for the Coinbase key if your multisig wallet was created earlier than June 2015.</small>
         </div>
         <div class="max_index">
           <p>Please enter the highest HD index to check for balance.</p>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,15 @@
         </header>
         <div class="xpubkeys">
           <p>Please enter the extended public keys (xpubkeys) for your multisig vault.</p>
+          <div class="xpubkey_header">
+            <small>Coinbase public key:</small>
+          </div>
+          <div class="xpubkey_header">
+            <small>Shared public key:</small>
+          </div>
+          <div class="xpubkey_header">
+            <small>User public key:</small>
+          </div>
           <textarea id="xpubkey1" class="xpubkey key" placeholder="xpub..."></textarea>
           <textarea id="xpubkey2" class="xpubkey key" placeholder="xpub..."></textarea>
           <textarea id="xpubkey3" class="xpubkey key" placeholder="xpub..."></textarea>

--- a/lib/tool.js
+++ b/lib/tool.js
@@ -19,7 +19,7 @@ $(function() {
 
   // Parse query string and prepopulate.
   var query = window.location.search.substring(1);
-  if (query) {
+  if (query.length != 0) {
     var key_to_element = {
       'xpubkey1':            '#xpubkey1',
       'xpubkey2':            '#xpubkey2',
@@ -38,12 +38,14 @@ $(function() {
 
       // Special case for handling which xpubkey's descendents should be compressed.
       if (key == 'compressed[]') {
-        $("#xpubkey" + value).data('compressed', 'true');
+        $("#xpubkey" + value + "_compressed").prop('checked', true);
       }
 
       // Look up the element from the key_to_element table and prefill it with the value.
       $(key_to_element[key]).val(value);
     }
+  } else { // no query string, assume Coinbase key is compressed
+    $("#xpubkey1_compressed").prop('checked', true);
   }
 
   // Hide all the steps, then only show step 1.
@@ -59,16 +61,12 @@ $(function() {
 
   // Step 1, collect the xpubkeys, construct child addresses and fetch their unspent outputs.
   $('#step_1 button').on('click', function() {
-    // Assume the first public key (Coinbase's key) is compressed. Can be overridden by URI param.
-    if (typeof ($('#xpubkey1').data('compressed')) === 'undefined') {
-      $('#xpubkey1').data('compressed','true');
-    }
     var lastAddressIndex = $('.max_index input').val();
     var xpubkeys = [];
     $('.xpubkey').each(function(i, xpub) {
       xpubkeys.push([
         cleanInput($(xpub).val()),
-        ($(xpub).data('compressed') == 'true')
+        $("#"+$(xpub).attr('id')+'_compressed').is(':checked')
       ]);
     });
 

--- a/lib/tool.js
+++ b/lib/tool.js
@@ -59,6 +59,10 @@ $(function() {
 
   // Step 1, collect the xpubkeys, construct child addresses and fetch their unspent outputs.
   $('#step_1 button').on('click', function() {
+    // Assume the first public key (Coinbase's key) is compressed. Can be overridden by URI param.
+    if (typeof ($('#xpubkey1').data('compressed')) === 'undefined') {
+      $('#xpubkey1').data('compressed','true');
+    }
     var lastAddressIndex = $('.max_index input').val();
     var xpubkeys = [];
     $('.xpubkey').each(function(i, xpub) {


### PR DESCRIPTION
fbc7d4d7e2f7cbe04d4ae26152a21c5fc1a1d387 has introduced URL handling of
a "compressed" boolean per public key. The primary purpose is to
signal the tool that one of the keys is compressed. That works well when
the fields are pre-populated from the Coinbase url.

However this has broken another use-case of the recovery tool. Directly
inputting the public keys from the printed vault backup, or
copy-pasting them manually from the 'vault details' page on Coinbase
will yield incorrect addresses, as the code will make the assumption
that the coinbase key is uncompressed. This commit fixes it.

As the 3 keys are not interchangeable anymore, the fields are now named
and the keys need to be entered in the correct fields.