### PR TITLE
Validating user/shared seeds correspond to xpubkeys

### DIFF
--- a/lib/multisig/generateHdWallet.js
+++ b/lib/multisig/generateHdWallet.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// Dependencies.
+var Bitcoin = require('bitcoinjs-lib');
+
+module.exports = function(seed_or_xprvkey) {
+  // Dealing with a seed.
+  if (seed_or_xprvkey.match(/^(L|K)[a-zA-Z0-9]*$/)) {
+    var key = Bitcoin.ECKey.fromWIF(seed_or_xprvkey);
+    return Bitcoin.HDNode.fromSeedBuffer(key.d.toBuffer());
+  }
+
+  // Dealing with a extended private key.
+  if (seed_or_xprvkey.match(/^xprv[a-zA-Z0-9]*$/)) {
+    return Bitcoin.HDNode.fromBase58(seed_or_xprvkey);
+  }
+
+  return false;
+};

--- a/lib/multisig/transaction.js
+++ b/lib/multisig/transaction.js
@@ -3,8 +3,10 @@
 // Dependencies.
 var Bitcoin = require('bitcoinjs-lib');
 var Buffer = require('buffer');
+
+var generateHdWallet = require('./generateHdWallet');
 var constants = require('./constants');
-var utils = require('./utils')
+var utils = require('./utils');
 
 /***
 Transaction builder */
@@ -51,27 +53,13 @@ Transaction.prototype = {
   addOutput: function() {
     this.tb.addOutput(this.destinationAddress, this.destinationAmount);
   },
-  generateHdWallet: function(seed_or_xprvkey) {
-    // Dealing with a seed.
-    if (seed_or_xprvkey.match(/^(L|K)[a-zA-Z0-9]*$/)) {
-      var key = Bitcoin.ECKey.fromWIF(seed_or_xprvkey);
-      return Bitcoin.HDNode.fromSeedBuffer(key.d.toBuffer());
-    }
-
-    // Dealing with a extended private key.
-    if (seed_or_xprvkey.match(/^xprv[a-zA-Z0-9]*$/)) {
-      return Bitcoin.HDNode.fromBase58(seed_or_xprvkey);
-    }
-
-    return false;
-  },
   signInputs: function() {
     var that = this;
 
     // Generate the HD wallets.
     this.hdWallets = [
-      this.generateHdWallet(this.seeds.shared),
-      this.generateHdWallet(this.seeds.user)
+      generateHdWallet(this.seeds.shared),
+      generateHdWallet(this.seeds.user)
     ];
 
     // Generate a random thing to sign.

--- a/lib/multisig/vault.js
+++ b/lib/multisig/vault.js
@@ -1,9 +1,11 @@
 "use strict";
 
 var Bitcoin = require('bitcoinjs-lib');
+
 var Address = require('./address');
 var Transaction = require('./transaction');
 var Bip38Worker = require('./bip38worker');
+var generateHdWallet = require('./generateHdWallet');
 var constants = require('./constants');
 var utils = require('./utils');
 
@@ -65,6 +67,23 @@ Vault.prototype = {
       address.getUnspentOutputs().done(this.updateBalance.bind(this));
     }
   },
+  xpubkeysIncludeSeed: function(seed) {
+    var node = generateHdWallet(seed);
+    if (!node) {
+      return false;
+    }
+
+    var xpub = node.neutered().toBase58();
+    if (!xpub) {
+      return false;
+    }
+
+    if (!this.xpubkeys.length) {
+      return false;
+    }
+
+    return this.xpubkeys.filter(function(xpk) { return xpk[0] == xpub; }).length > 0;
+  },
   buildTransaction: function(options) {
     this.tx = new Transaction({
       addresses: this.addresses,
@@ -76,6 +95,12 @@ Vault.prototype = {
     });
 
     this.tx.onReady = options.onReady;
+
+    // Validate user key.
+    if (!this.xpubkeysIncludeSeed(this.tx.seeds.user)) {
+      var err = new Error('The user seed does not correspond to a xpubkey.');
+      this.tx.onReady(err);
+    }
 
     // Build transaction.
     this.tx.addInputs();
@@ -92,6 +117,12 @@ Vault.prototype = {
     // Use the just decrypted seed.
     this.tx.seeds.shared = shared_seed;
 
+    // Validate decrypted shared key.
+    if (!this.xpubkeysIncludeSeed(shared_seed)) {
+      var err = new Error('The shared encrypted seed password is incorrect.');
+      this.tx.onReady(err);
+    }
+
     // Sign transaction.
     this.tx.signInputs();
 
@@ -101,6 +132,6 @@ Vault.prototype = {
     // Call ready callback.
     this.tx.onReady();
   }
-}
+};
 
 module.exports = Vault;

--- a/lib/tool.js
+++ b/lib/tool.js
@@ -135,7 +135,12 @@ $(function() {
         percent = cur_percent;
         $('#decrypt_percent').text(percent);
       },
-      onReady: function() {
+      onReady: function(err) {
+        if (err) {
+          alert(err.message);
+          throw err;
+        }
+
         $('.fees_btc').text(vault.tx.getMinerFee());
         $('.total_btc').text(vault.tx.getDestinationAmount());
         $('.raw code').text(vault.tx.transaction.toHex());


### PR DESCRIPTION
We did not do any checking before whether the password the user provided
resulted in a valid decrypted seed that corresponds to one of the
xpubkeys.

We also did not check if the unencrypted user seed corresponds to one of
the xpubkeys.

This resulted in a bad UX whereas user error would result in weird
errors that seemed like a problem in the code.